### PR TITLE
Add idempotency keys

### DIFF
--- a/drizzle/0005_lethal_lilith.sql
+++ b/drizzle/0005_lethal_lilith.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `audit_logs` ADD `idempotency_key` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `audit_logs_idempotency_key_unique` ON `audit_logs` (`idempotency_key`);

--- a/drizzle/0006_slim_psylocke.sql
+++ b/drizzle/0006_slim_psylocke.sql
@@ -1,0 +1,2 @@
+DROP INDEX `audit_logs_idempotency_key_unique`;--> statement-breakpoint
+CREATE UNIQUE INDEX `audit_logs_app_id_idempotency_key_idx` ON `audit_logs` (`app_id`,`idempotency_key`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,369 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fcde1b99-43d9-4572-ac90-2eeca4e74239",
+  "prevId": "62bd46cd-70ce-43ac-bb21-d5f9c5e14df1",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_money_movement": {
+          "name": "allow_money_movement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_card_access": {
+          "name": "allow_card_access",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "app_id_idx": {
+          "name": "app_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "app_api_key_hash_idx": {
+          "name": "app_api_key_hash_idx",
+          "columns": [
+            "api_key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_ip": {
+          "name": "user_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "audit_logs_idempotency_key_unique": {
+          "name": "audit_logs_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "audit_logs_app_id_timestamp_idx": {
+          "name": "audit_logs_app_id_timestamp_idx",
+          "columns": [
+            "app_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_timestamp_idx": {
+          "name": "audit_logs_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_method_idx": {
+          "name": "audit_logs_method_idx",
+          "columns": [
+            "method"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_response_status_idx": {
+          "name": "audit_logs_response_status_idx",
+          "columns": [
+            "response_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_app_id_apps_id_fk": {
+          "name": "audit_logs_app_id_apps_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_config": {
+      "name": "auth_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "oauth_tokens_oauth_client_id_unique": {
+          "name": "oauth_tokens_oauth_client_id_unique",
+          "columns": [
+            "oauth_client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_tokens_expires_at_idx": {
+          "name": "oauth_tokens_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "oauth_tokens_updated_at_idx": {
+          "name": "oauth_tokens_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "oauth_tokens_oauth_client_id_idx": {
+          "name": "oauth_tokens_oauth_client_id_idx",
+          "columns": [
+            "oauth_client_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,370 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1588d756-6820-482b-ac02-0358e507c7e4",
+  "prevId": "fcde1b99-43d9-4572-ac90-2eeca4e74239",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_money_movement": {
+          "name": "allow_money_movement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_card_access": {
+          "name": "allow_card_access",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "app_id_idx": {
+          "name": "app_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "app_api_key_hash_idx": {
+          "name": "app_api_key_hash_idx",
+          "columns": [
+            "api_key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_ip": {
+          "name": "user_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "audit_logs_app_id_timestamp_idx": {
+          "name": "audit_logs_app_id_timestamp_idx",
+          "columns": [
+            "app_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_timestamp_idx": {
+          "name": "audit_logs_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_method_idx": {
+          "name": "audit_logs_method_idx",
+          "columns": [
+            "method"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_response_status_idx": {
+          "name": "audit_logs_response_status_idx",
+          "columns": [
+            "response_status"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_app_id_idempotency_key_idx": {
+          "name": "audit_logs_app_id_idempotency_key_idx",
+          "columns": [
+            "app_id",
+            "idempotency_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_app_id_apps_id_fk": {
+          "name": "audit_logs_app_id_apps_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_config": {
+      "name": "auth_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "oauth_tokens_oauth_client_id_unique": {
+          "name": "oauth_tokens_oauth_client_id_unique",
+          "columns": [
+            "oauth_client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_tokens_expires_at_idx": {
+          "name": "oauth_tokens_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "oauth_tokens_updated_at_idx": {
+          "name": "oauth_tokens_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "oauth_tokens_oauth_client_id_idx": {
+          "name": "oauth_tokens_oauth_client_id_idx",
+          "columns": [
+            "oauth_client_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1759140335717,
       "tag": "0004_tearful_jigsaw",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1759261981419,
+      "tag": "0005_lethal_lilith",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1759261981419,
       "tag": "0005_lethal_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1759263070681,
+      "tag": "0006_slim_psylocke",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,6 +1,7 @@
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
 import { nanoid } from 'nanoid';
 import { sql } from 'drizzle-orm';
+import { uniqueIndex } from 'drizzle-orm/pg-core';
 
 export const app = sqliteTable(
 	'apps',
@@ -75,6 +76,7 @@ export const auditLog = sqliteTable(
 		responseStatus: integer('response_status').notNull(),
 		responseHeaders: text('response_headers').notNull(),
 		responseBody: text('response_body'),
+		idempotencyKey: text('idempotency_key').unique(),
 		timestamp: text('timestamp')
 			.default(sql`(CURRENT_TIMESTAMP)`)
 			.notNull()
@@ -83,6 +85,8 @@ export const auditLog = sqliteTable(
 		index('audit_logs_app_id_timestamp_idx').on(table.appId, table.timestamp),
 		index('audit_logs_timestamp_idx').on(table.timestamp),
 		index('audit_logs_method_idx').on(table.method),
-		index('audit_logs_response_status_idx').on(table.responseStatus)
+		index('audit_logs_response_status_idx').on(table.responseStatus),
 	]
 );
+
+export type AuditLog = typeof auditLog.$inferSelect;

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,7 +1,6 @@
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, index, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import { nanoid } from 'nanoid';
 import { sql } from 'drizzle-orm';
-import { uniqueIndex } from 'drizzle-orm/pg-core';
 
 export const app = sqliteTable(
 	'apps',
@@ -76,7 +75,7 @@ export const auditLog = sqliteTable(
 		responseStatus: integer('response_status').notNull(),
 		responseHeaders: text('response_headers').notNull(),
 		responseBody: text('response_body'),
-		idempotencyKey: text('idempotency_key').unique(),
+		idempotencyKey: text('idempotency_key'),
 		timestamp: text('timestamp')
 			.default(sql`(CURRENT_TIMESTAMP)`)
 			.notNull()
@@ -86,6 +85,7 @@ export const auditLog = sqliteTable(
 		index('audit_logs_timestamp_idx').on(table.timestamp),
 		index('audit_logs_method_idx').on(table.method),
 		index('audit_logs_response_status_idx').on(table.responseStatus),
+		uniqueIndex('audit_logs_app_id_idempotency_key_idx').on(table.appId, table.idempotencyKey)
 	]
 );
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -90,3 +90,4 @@ export const auditLog = sqliteTable(
 );
 
 export type AuditLog = typeof auditLog.$inferSelect;
+export type App = typeof app.$inferSelect;

--- a/src/routes/api/v4/[...path]/+server.ts
+++ b/src/routes/api/v4/[...path]/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { getValidTokenResponse } from '$lib/server/oauth';
 import { db } from '$lib/server/db/index';
-import { app, auditLog, type AuditLog } from '$lib/server/db/schema';
+import { app, auditLog, type AuditLog, type App } from '$lib/server/db/schema';
 import { env } from '$env/dynamic/private';
 import micromatch from 'micromatch';
 import type { RequestEvent } from './$types';
@@ -12,13 +12,6 @@ import { sha256 } from '$lib/utils';
 interface PermissionCheck {
 	allowed: boolean;
 	required?: string;
-}
-
-interface AppData {
-	id: string;
-	allowMoneyMovement: boolean;
-	allowCardAccess: boolean;
-	apiKeyHash: string;
 }
 
 // Constants
@@ -60,14 +53,14 @@ const HEADERS_TO_EXCLUDE = [
 
 const HEADERS_TO_REDACT = ['authorization'] as const;
 
-function checkPermissions(method: string, path: string, appData: AppData): PermissionCheck {
+function checkPermissions(method: string, path: string, app: App): PermissionCheck {
 	const route = `${method} ${path}`;
 
-	if (!appData.allowMoneyMovement && micromatch.isMatch(route, MONEY_MOVEMENT_ROUTES)) {
+	if (!app.allowMoneyMovement && micromatch.isMatch(route, MONEY_MOVEMENT_ROUTES)) {
 		return { allowed: false, required: 'allowMoneyMovement' };
 	}
 
-	if (!appData.allowCardAccess && micromatch.isMatch(route, CARD_ACCESS_ROUTES)) {
+	if (!app.allowCardAccess && micromatch.isMatch(route, CARD_ACCESS_ROUTES)) {
 		return { allowed: false, required: 'allowCardAccess' };
 	}
 

--- a/src/routes/api/v4/[...path]/+server.ts
+++ b/src/routes/api/v4/[...path]/+server.ts
@@ -117,14 +117,21 @@ async function handleProxyRequest({ request, url, getClientAddress }: RequestEve
 
 	let auditLogEntry: AuditLog | null = null;
 	if (idempotencyKey && DATA_MUTATION_METHODS.includes(method as any)) {
-		auditLogEntry = await createInitialAuditLog(
-			validApp.id,
-			request,
-			requestBody,
-			filteredRequestHeaders,
-			targetPath,
-			userIp
-		);
+		try {
+			auditLogEntry = await createInitialAuditLog(
+				validApp.id,
+				request,
+				requestBody,
+				filteredRequestHeaders,
+				targetPath,
+				userIp
+			);
+		} catch (error) {
+			return json(
+				{ error: `Failed to create initial audit log: ${error}. This probably means that you reused an idempotency key.` },
+				{ status: 409 }
+			);
+		}
 	}
 
 	if (!env.HCB_CLIENT_ID) {


### PR DESCRIPTION
Here's how it works:
- For data mutating requests, set an optional `X-Idempotency-Key` header.
- If there's a collision:
  - If request body is the same, we just return the old response body (this is how Stripe does it)
  - If it isn't, we return a `409 Conflict`

Fixes #5, workaround for hackclub/hcb#11764.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add idempotency keys for data-mutating API requests to prevent duplicate processing and enable safe retries. On key collisions, identical bodies return the original response; different bodies return 409 Conflict.

- **New Features**
  - Support X-Idempotency-Key on POST/PUT/PATCH/DELETE through the /api/v4 proxy.
  - Persist keys in audit_logs with a unique index on (app_id, idempotency_key).
  - Improved audit logging (safe body reads, authorization header redaction) and safer proxy header forwarding.

- **Migration**
  - Run Drizzle migrations 0005 and 0006.
  - Clients should include X-Idempotency-Key for retriable, mutating requests.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Idempotent API requests: repeat calls with the same idempotency key return the original result, preventing duplicate operations.
  - Route-based access control: permissions are now enforced per route pattern for money movement and card access, providing clearer, more predictable access rules.
  - Enhanced auditing: requests and responses are logged with sensitive headers redacted for improved traceability and privacy.
- Bug Fixes
  - More consistent proxying behavior and header handling when forwarding requests, reducing edge-case failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->